### PR TITLE
address Bio.Alphabet removal in Biopython 1.78

### DIFF
--- a/kleborate/truncation.py
+++ b/kleborate/truncation.py
@@ -13,7 +13,6 @@ not, see <http://www.gnu.org/licenses/>.
 """
 
 from Bio.Seq import Seq
-from Bio.Alphabet import IUPAC
 
 from .misc import reverse_complement
 
@@ -51,7 +50,7 @@ def truncation_check(hit, cov_threshold=90.0):
     # denominator for coverage.
     ref_aa_length = (hit.ref_length - 3) // 3
 
-    coding_dna = Seq(nucl_seq, IUPAC.unambiguous_dna)
+    coding_dna = Seq(nucl_seq)
     translation = str(coding_dna.translate(table='Bacterial', to_stop=True))
 
     coverage = 100.0 * len(translation) / ref_aa_length


### PR DESCRIPTION
Greetings,

In version 1.78, Biopython removed the deprecated Bio.Alphabet module.  This patch follows recommendations published on https://biopython.org/wiki/Alphabet to allow Kleborate to run with this Biopython version.

The test suite would otherwise fail with the following backtraces:

    ======================================================================
    ERROR: test.test_genomes (unittest.loader._FailedTest)
    ----------------------------------------------------------------------
    ImportError: Failed to import test module: test.test_genomes
    Traceback (most recent call last):
      File "/usr/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
        module = self._get_module_from_name(name)
      File "/usr/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
        __import__(name)
      File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.8/build/test/test_genomes.py", line 18, in <module>
        from kleborate.kleborate import get_data_path, get_output_headers, gunzip_contigs_if_necessary, \
      File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.8/build/kleborate/kleborate.py", line 28, in <module>
        from .resBLAST import read_class_file, get_res_headers, resblast_one_assembly
      File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.8/build/kleborate/resBLAST.py", line 25, in <module>
        from .truncation import truncation_check
      File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.8/build/kleborate/truncation.py", line 16, in <module>
        from Bio.Alphabet import IUPAC
      File "/usr/lib/python3/dist-packages/Bio/Alphabet/__init__.py", line 20, in <module>
        raise ImportError(
    ImportError: Bio.Alphabet has been removed from Biopython. In many cases, the alphabet can simply be ignored and removed from scripts. In a few cases, you may need to specify the ``molecule_type`` as an annotation on a SeqRecord for your script to work correctly. Please see https://biopython.org/wiki/Alphabet for more information.

In hope it helps,
Kind Regards,
Étienne.